### PR TITLE
Added PlayerActivity In Navigation Graphs

### DIFF
--- a/app/src/main/java/com/talent/animescrap/ui/activities/PlayerActivity.kt
+++ b/app/src/main/java/com/talent/animescrap/ui/activities/PlayerActivity.kt
@@ -1,6 +1,7 @@
 package com.talent.animescrap.ui.activities
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.app.PictureInPictureParams
 import android.app.UiModeManager
 import android.content.Intent
@@ -15,6 +16,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.CountDownTimer
 import android.support.v4.media.session.MediaSessionCompat
+import android.util.Log
 import android.view.View
 import android.widget.*
 import androidx.activity.OnBackPressedCallback
@@ -24,6 +26,8 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.isVisible
+import androidx.navigation.findNavController
+import androidx.navigation.navArgs
 import androidx.preference.PreferenceManager
 import com.google.android.exoplayer2.*
 import com.google.android.exoplayer2.database.StandaloneDatabaseProvider
@@ -98,6 +102,7 @@ class PlayerActivity : AppCompatActivity() {
     private var simpleCache: SimpleCache? = null
     private val mCookieManager = CookieManager()
     private val animeStreamViewModelInPlayer: AnimeStreamViewModel by viewModels()
+    private val args : PlayerActivityArgs by navArgs()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -130,12 +135,8 @@ class PlayerActivity : AppCompatActivity() {
         sharedPreferences = getSharedPreferences("LastWatchedPref", MODE_PRIVATE)
 
         // Arguments
-        val animePlayingDetails: AnimePlayingDetails? =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                intent.getParcelableExtra("animePlayingDetails", AnimePlayingDetails::class.java)
-            } else {
-                @Suppress("DEPRECATION") intent.getParcelableExtra("animePlayingDetails")
-            }
+        val animePlayingDetails = args.animePlayingDetails
+
         animeName = animePlayingDetails!!.animeName
         animeEpisode = animePlayingDetails.animeEpisodeIndex
         animeTotalEpisode = animePlayingDetails.animeTotalEpisode
@@ -207,7 +208,8 @@ class PlayerActivity : AppCompatActivity() {
             } else {
                 Toast.makeText(this, "No streaming URL found", Toast.LENGTH_SHORT)
                     .show()
-                backPressed()
+                val navController = findNavController(R.id.nav_host_fragment_activity_main_bottom_nav)
+                navController.popBackStack()
             }
         }
 

--- a/app/src/main/java/com/talent/animescrap/ui/fragments/AnimeFragment.kt
+++ b/app/src/main/java/com/talent/animescrap/ui/fragments/AnimeFragment.kt
@@ -28,7 +28,6 @@ import com.talent.animescrap.databinding.FragmentAnimeBinding
 import com.talent.animescrap.model.AnimeDetails
 import com.talent.animescrap.model.AnimePlayingDetails
 import com.talent.animescrap.model.AnimeStreamLink
-import com.talent.animescrap.ui.activities.PlayerActivity
 import com.talent.animescrap.ui.viewmodels.AnimeDetailsViewModel
 import com.talent.animescrap.ui.viewmodels.AnimeStreamViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -170,19 +169,18 @@ class AnimeFragment : Fragment() {
 
             // Navigate to Internal Player
             if (!isExternalPlayerEnabled) {
-
-                startActivity(Intent(requireContext(), PlayerActivity::class.java).apply {
-                    putExtra(
-                        "animePlayingDetails", AnimePlayingDetails(
-                            animeName = animeName!!,
-                            animeUrl = animeMainLink!!,
-                            animeEpisodeIndex = epIndex,
-                            animeEpisodeMap = animeEpisodesMap[epType] as HashMap<String, String>,
-                            animeTotalEpisode = animeEpisodesMap[epType]!!.size.toString(),
-                            epType = epType
-                        )
+                val action = AnimeFragmentDirections.actionNavigationAnimeToPlayerActivity(
+                    AnimePlayingDetails(
+                        animeName = animeName!!,
+                        animeUrl = animeMainLink!!,
+                        animeEpisodeIndex = epIndex,
+                        animeEpisodeMap = animeEpisodesMap[epType] as HashMap<String, String>,
+                        animeTotalEpisode = animeEpisodesMap[epType]!!.size.toString(),
+                        epType = epType
                     )
-                })
+                )
+
+                findNavController().navigate(action)
 
             } else {
                 binding.progressbarInPage.visibility = View.VISIBLE
@@ -193,10 +191,7 @@ class AnimeFragment : Fragment() {
                     listOf(epType)
                 )
             }
-
         }
-
-
     }
 
     private fun startExternalPlayer(

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -73,10 +73,24 @@
             android:name="animeLink"
             app:argType="string"
             app:nullable="true" />
+        <action
+            android:id="@+id/action_navigation_anime_to_playerActivity"
+            app:destination="@id/playerActivity" />
     </fragment>
 
     <fragment
         android:id="@+id/navigation_settings"
         android:name="com.talent.animescrap.ui.fragments.SettingsFragment"
         android:label="@string/settings" />
+
+    <activity
+        android:id="@+id/playerActivity"
+        android:name="com.talent.animescrap.ui.activities.PlayerActivity"
+        android:label="activity_player"
+        tools:layout="@layout/activity_player" >
+        <argument
+            android:name="animePlayingDetails"
+            app:argType="com.talent.animescrap.model.AnimePlayingDetails"
+            app:nullable="true"/>
+    </activity>
 </navigation>


### PR DESCRIPTION
- Inside the PlayerActivity if the 'animeStreamLink' is blank then onBackPressed() method is called which brings the user back to the "LatestFragment" thus not giving the proper backstack because it should go back to the "AnimeFragment". 
- After adding the PlayerActivity in Navigation Graphs this problem is solved and improves the user experience.